### PR TITLE
Upgrading halstack-react version

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1408,9 +1408,9 @@
       "integrity": "sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw=="
     },
     "@dxc-technology/halstack-react": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dxc-technology/halstack-react/-/halstack-react-8.0.0.tgz",
-      "integrity": "sha512-dX2prgWovPJhegbicrwR3zcIucSfUnsw5CPjv7qpUaRQJoapyoGtp/blNupYvGyuJca8yQACz6or3yiXHMLgPg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dxc-technology/halstack-react/-/halstack-react-9.0.0.tgz",
+      "integrity": "sha512-PGoIds9MPy4O6N6GB4yN+QLYuYcJyOW/GYxJFLanY/9bhp1a9A9fjXjrAdAKGdAVMkR4m9d74kAT+lT6RaIURg==",
       "requires": {
         "@radix-ui/react-popover": "0.1.6",
         "@types/styled-components": "^5.1.24",
@@ -18405,9 +18405,9 @@
       }
     },
     "aria-hidden": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.2.tgz",
-      "integrity": "sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
       "requires": {
         "tslib": "^2.0.0"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@dxc-technology/halstack-react": "8.0.0",
+    "@dxc-technology/halstack-react": "^9.0.0",
     "@dxc-technology/halstack-react-hal": "file:../lib",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.13.0",

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1547,9 +1547,9 @@
       }
     },
     "@dxc-technology/halstack-react": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dxc-technology/halstack-react/-/halstack-react-8.0.0.tgz",
-      "integrity": "sha512-dX2prgWovPJhegbicrwR3zcIucSfUnsw5CPjv7qpUaRQJoapyoGtp/blNupYvGyuJca8yQACz6or3yiXHMLgPg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dxc-technology/halstack-react/-/halstack-react-9.0.0.tgz",
+      "integrity": "sha512-PGoIds9MPy4O6N6GB4yN+QLYuYcJyOW/GYxJFLanY/9bhp1a9A9fjXjrAdAKGdAVMkR4m9d74kAT+lT6RaIURg==",
       "dev": true,
       "requires": {
         "@radix-ui/react-popover": "0.1.6",
@@ -4017,9 +4017,9 @@
       }
     },
     "aria-hidden": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.2.tgz",
-      "integrity": "sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.0.0"

--- a/lib/package.json
+++ b/lib/package.json
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "react": "^18.x",
     "react-dom": "^18.x",
-    "@dxc-technology/halstack-react": "^8.0.0"
+    "@dxc-technology/halstack-react": "^9.0.0"
   },
   "dependencies": {
     "@dxc-technology/halstack-client": "^1.3.3"
@@ -32,7 +32,7 @@
     "@babel/plugin-transform-runtime": "^7.10.1",
     "@babel/preset-env": "^7.6.2",
     "@babel/preset-react": "^7.0.0",
-    "@dxc-technology/halstack-react": "8.0.0",
+    "@dxc-technology/halstack-react": "^9.0.0",
     "@types/react": "^18.0.27",
     "@types/styled-components": "^5.1.26",
     "@types/jest": "^29.4.0",


### PR DESCRIPTION
Upgrade `halstack-react` library dependencies to the [latest version](https://github.com/dxc-technology/halstack-react/releases/tag/9.0.0) released (9.0.0).