### PR TITLE
New types for HAL resource

### DIFF
--- a/lib/src/hooks/types.ts
+++ b/lib/src/hooks/types.ts
@@ -24,12 +24,101 @@ export type UseHalResource = {
 
 export type RequestStatus = "idle" | "fetching" | "resolved" | "rejected" | "interaction";
 
+type InteractionType = Record<string, unknown> & {
+  rel: string;
+  href: string;
+};
+
+type OptionsProperty = {
+  key: string;
+  schema: Record<string, unknown>;
+};
+
+type PropertyType = {
+  key: string;
+  value: unknown;
+};
+
+type HalInteractionType = InteractionType & {
+  getSchemaProperties: () => OptionsProperty[];
+  getSchemaProperty: (key: string) => OptionsProperty | null;
+  hasProperty: (property: string) => boolean;
+  getRequiredProperties: () => string[];
+  isPropertyRequired: (key: string) => boolean;
+  addSchemaProperties: (properties: OptionsProperty[]) => void;
+  addSchemaProperty: (property: OptionsProperty, schema: Record<string, unknown>) => void;
+};
+
+type HalItemType = {
+  href: string;
+  summary?: unknown;
+  title: string;
+  name: string;
+};
+
+type LinkType = Record<string, unknown> & {
+  rel: string;
+};
+
+type HalPropertyType = PropertyType & {
+  isRequired: () => boolean;
+  getSchema: () => OptionsProperty | null;
+  existsInInteraction: (rel: string) => boolean;
+};
+
+type ItemType = Record<string, unknown> & {
+  href: string;
+};
+
+type OptionsType = {
+  links: InteractionType[];
+  properties?: OptionsProperty[];
+  title: string;
+  required?: string[];
+};
+
+export type HalResourceType = {
+  resourceRepresentation?: unknown;
+  getTitle: () => string;
+  getInteractions: () => HalInteractionType[];
+  getInteraction: (rel: string) => HalInteractionType;
+  getItems: () => HalItemType[];
+  getItem: (index: number) => HalItemType | null;
+  getLinks: () => LinkType[];
+  getLink: (rel: string) => LinkType | null;
+  getProperties: () => HalPropertyType[];
+  getProperty: (key: string) => HalPropertyType | null;
+  getSchemaProperties: () => OptionsProperty[];
+  getSchemaProperty: (key: string) => OptionsProperty | null;
+  getRequiredProperties: () => string[];
+
+  addLink: (link: LinkType) => void;
+  addLinks: (links: LinkType[]) => void;
+  addItem: (item: ItemType) => void;
+  addItems: (items: ItemType[]) => void;
+  addProperty: (property: PropertyType) => void;
+  addProperties: (properties: PropertyType[]) => void;
+
+  addOptionsProperties: (properties: OptionsProperty[]) => void;
+  addOptionsProperty: (property: OptionsProperty) => void;
+  addTitle: (title: string) => void;
+  addInteraction: (interaction: InteractionType) => void;
+  addOptions: (options: OptionsType[]) => void;
+};
+
+export type Interactions = Record<string, unknown>;
+
 /**
  * Array with the following stateful variables.
  *    - resource: HalResource
  *    - requestStatus: 'idle' | 'fetching' | 'resolved' | 'rejected' | 'interaction'
  *    - requestError: ErrorResponse
- *    - resourceInteractions: object. This is an object containing as many entries as interactions (_options.links) are available in the HAL resource. 
+ *    - resourceInteractions: object. This is an object containing as many entries as interactions (_options.links) are available in the HAL resource.
  *      Each entry has the rel value of the interaction as a key, and a function that you can execute passing a payload as a parameter.
  */
-export type UseHalResourceResponse = [any, RequestStatus, ErrorResponse, any];
+export type UseHalResourceResponse = [
+  HalResourceType | undefined,
+  RequestStatus,
+  ErrorResponse | undefined,
+  Interactions | undefined
+];

--- a/lib/src/hooks/useHalResource.tsx
+++ b/lib/src/hooks/useHalResource.tsx
@@ -1,6 +1,13 @@
 import { useState, useEffect } from "react";
 import { HalApiCaller } from "@dxc-technology/halstack-client";
-import { ErrorResponse, RequestStatus, UseHalResource, UseHalResourceResponse } from "./types";
+import {
+  ErrorResponse,
+  HalResourceType,
+  Interactions,
+  RequestStatus,
+  UseHalResource,
+  UseHalResourceResponse,
+} from "./types";
 
 const buildErrorResponse = (error) => {
   const errorResponse: ErrorResponse = {
@@ -21,8 +28,8 @@ const useHalResource = ({
 }: UseHalResource): UseHalResourceResponse => {
   const [status, setStatus] = useState<RequestStatus>("idle");
   const [error, setError] = useState<ErrorResponse>();
-  const [resource, setResource] = useState<object>(null);
-  const [interactions, setInteractions] = useState<object>(null);
+  const [resource, setResource] = useState<HalResourceType>();
+  const [interactions, setInteractions] = useState<Interactions>();
 
   useEffect(() => {
     const getInteractionHandler = (method, resourceSelf, methodHref) => {
@@ -65,7 +72,7 @@ const useHalResource = ({
       };
     };
 
-    const getInteractions = (halResource) => {
+    const getInteractions = (halResource: HalResourceType) => {
       return halResource
         .getInteractions()
         .map((interaction) => ({
@@ -98,7 +105,7 @@ const useHalResource = ({
           setInteractions(getInteractions(response.halResource));
           setStatus("resolved");
         } else {
-          setResource(null);
+          setResource(undefined);
           const errorResponse = buildErrorResponse({
             message: "Response does not contain a valid HAL resource",
           });
@@ -106,7 +113,7 @@ const useHalResource = ({
           setStatus("rejected");
         }
       } catch (err) {
-        setResource(null);
+        setResource(undefined);
         setError(buildErrorResponse(err));
         setStatus("rejected");
       }


### PR DESCRIPTION
### Description
Since other teams are adopting Typescript in their UIs, we need the hook `useHalResource` to return a correctly typed array.

### Changes
- Added new types based on Halstack React HAL and Halstack Client libraries.
- Updated `useHalResource` with the new types.